### PR TITLE
update postgres version for local development

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   shortdb:
     container_name: shortdb
-    image: postgres:12
+    image: postgres:14
     env_file:
       - .env
     environment:


### PR DESCRIPTION
Prisma migration was failing because our Postgres version is 12 and that does not support the gen_random_uuid() function. We have a script that enables `pgcrypto` extension but this was not working as we also have to make some changes to the Prisma schema which will affect our prod db.