### PR TITLE
pick prefix from env

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -34,7 +34,7 @@ async function bootstrap() {
   //   },
   // });
 
-  const globalPrefix = 'api';
+  const globalPrefix = process.env.APP_GLOBAL_PREFIX || '';
   app.setGlobalPrefix(globalPrefix);
 
   const config = new DocumentBuilder()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "nx serve",
+    "start": "nx serve api",
     "build": "nx build",
     "test": "nx test",
     "prepare": "husky install"

--- a/sample.env
+++ b/sample.env
@@ -1,3 +1,4 @@
+APP_GLOBAL_PREFIX=
 POSTGRES_DB=shortdb
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=yoursupersecret


### PR DESCRIPTION
Instead of hard-coding app global prefix, we are picking that up from .env